### PR TITLE
Modify UpgradeData to correctly handle template JSON formats

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -15,11 +15,6 @@ class UpgradeData implements UpgradeDataInterface
     protected $saveFactory;
 
     /**
-     * @var
-     */
-    protected $connection;
-
-    /**
      * @var \Magento\Framework\App\ResourceConnection
      */
     protected $resource;
@@ -47,10 +42,10 @@ class UpgradeData implements UpgradeDataInterface
 
         if (version_compare($context->getVersion(), '0.0.2') < 0) {
             // Homepage CMS Page
-            $this->updateCmsPageContent('Home Page - Venia', $this->buildStructureFromTemplate(__DIR__ . '/venia-home-content.json'));
+            $this->updateCmsPageContent('Home Page - Venia', $this->buildStructureFromTemplate(__DIR__ . '/venia-home.json'));
 
             // CLP Tops Block CMS
-            $this->updateCmsBlockContent('venia-clp-tops', $this->buildStructureFromTemplate(__DIR__ . '/venia-clp-tops-content.json'));
+            $this->updateCmsBlockContent('venia-clp-tops', $this->buildStructureFromTemplate(__DIR__ . '/venia-clp-tops.json'));
         }
 
         $setup->endSetup();

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,5 @@
 {
     "name": "magentoese/module-venia-cms-sample-data",
-    "require": {
-        "magentoese/module-venia-media-sample-data": "*"
-    },
     "type": "magento2-module",
     "version": "0.0.2",
     "autoload": {


### PR DESCRIPTION
These changes allow previously exported template structures to be directly imported into Magento entities. 

Currently this code is very rigid and will require manual changes for other use cases. However if the JSON format has been correctly pulled from the template table it will parse, build and import it as expected.